### PR TITLE
Fixing issue #56 (tested in Firefox and Chrome)

### DIFF
--- a/excellentexport.js
+++ b/excellentexport.js
@@ -102,7 +102,7 @@ var ExcellentExport = (function() {
             return false;
         } else if(window.URL.createObjectURL) {
             blob = b64toBlob(base64data, exporttype);
-            var blobUrl = window.URL.createObjectURL(blob, exporttype, filename);
+            var blobUrl = window.URL.createObjectURL(blob);
             anchor.href = blobUrl;
         } else {
             var hrefvalue = "data:" + exporttype + ";base64," + base64data;


### PR DESCRIPTION
The `createObjectURL` need only the blob: https://w3c.github.io/FileAPI/#dfn-createObjectURL